### PR TITLE
Tutorial fixes

### DIFF
--- a/tutorial/scripts/common_wf.py
+++ b/tutorial/scripts/common_wf.py
@@ -13,7 +13,7 @@ PwCalculation = CalculationFactory('quantumespresso.pw')
 
 def generate_scf_input_params(structure, codename, pseudo_family):
     # The inputs
-    inputs = PwCalculation.process().get_inputs_template()
+    inputs = PwCalculation.get_builder()
 
     # The structure
     inputs.structure = structure
@@ -21,8 +21,8 @@ def generate_scf_input_params(structure, codename, pseudo_family):
     inputs.code = Code.get_from_string(codename)
     # calc.label = "PW test"
     # calc.description = "My first AiiDA calculation of Silicon with Quantum ESPRESSO"
-    inputs._options.resources = {"num_machines": 1}
-    inputs._options.max_wallclock_seconds = 30 * 60
+    inputs.options.resources = {"num_machines": 1}
+    inputs.options.max_wallclock_seconds = 30 * 60
 
     # Kpoints
     KpointsData = DataFactory("array.kpoints")

--- a/tutorial/scripts/equation_of_states.py
+++ b/tutorial/scripts/equation_of_states.py
@@ -34,7 +34,7 @@ class EquationOfStates(WorkChain):
         calcs = {}
         for label, factor in zip(labels, scale_facs):
             s = rescale(self.ctx.s0,Float(factor))
-            inputs = generate_scf_input_params(s, str(self.inputs.code), str(self.inputs.pseudo_family))
+            inputs = generate_scf_input_params(s, str(self.inputs.code), self.inputs.pseudo_family)
             print "Running a scf for {} with scale factor {}".format(self.inputs.element, factor)
             future = submit(JobCalc, **inputs)
             calcs[label] = Outputs(future)
@@ -62,7 +62,7 @@ def get_info(calc_results):
             calc_results['output_parameters'].dict.energy,
             calc_results['output_parameters'].dict.energy_units)
 
-def run_eos(element="Si", code='pw-5.1@localhost', pseudo_family='GBRV_lda'):
+def run_eos(element="Si", code='qe-pw-6.2.1@localhost', pseudo_family='GBRV_lda'):
     return run(EquationOfStates, element=Str(element), code=Str(code), pseudo_family=Str(pseudo_family))
 
 if __name__ == '__main__':

--- a/tutorial/scripts/pressure_convergence.py
+++ b/tutorial/scripts/pressure_convergence.py
@@ -4,12 +4,11 @@ if not is_dbenv_loaded():
     load_dbenv()
 
 from aiida.orm import load_node, CalculationFactory, DataFactory
-from aiida.orm.data.base import Float, Str, NumericType, BaseType
+from aiida.orm.data.base import Float, Str, NumericType
 from aiida.orm.code import Code
 from aiida.orm.data.structure import StructureData
 from aiida.work.run import run, submit
-from aiida.work.process_registry import ProcessRegistry
-from aiida.work.workchain import WorkChain, ToContext, while_, Outputs
+from aiida.work.workchain import WorkChain, ToContext, while_
 from common_wf import generate_scf_input_params
 from create_rescale import rescale, create_diamond_fcc
 
@@ -18,8 +17,8 @@ PwCalculation = CalculationFactory('quantumespresso.pw')
 
 GPa_to_eV_over_ang3 = 1./160.21766208
 
-def run_eos(structure, element="Si", code='pw-5.1@localhost', pseudo_family='GBRV_lda'):
-    return run(PressureConvergence, structure=structure, code=Str(code), pseudo_family=Str(pseudo_family), volume_tolerance=Float(0.1), _options={})
+def run_eos(structure, element="Si", code='pw-5.1', pseudo_family='GBRV_lda'):
+    return run(PressureConvergence, structure=structure, code=Str(code), pseudo_family=Str(pseudo_family), volume_tolerance=Float(0.1))
 
 
 # Set up the factories
@@ -101,7 +100,7 @@ class PressureConvergence(WorkChain):
     	super(PressureConvergence, cls).define(spec)
         spec.input("structure", valid_type=StructureData)
         spec.input("volume_tolerance", valid_type=Float) #, default=Float(0.1))
-        spec.input("code", valid_type=Code)
+        spec.input("code", valid_type=Str)
         spec.input("pseudo_family", valid_type=Str)
         spec.outline(
             cls.init,
@@ -112,7 +111,6 @@ class PressureConvergence(WorkChain):
             ),
             cls.report
         )
-        spec.dynamic_output()
 
     def init(self):
         """
@@ -120,10 +118,10 @@ class PressureConvergence(WorkChain):
         and a second calculation for a shifted volume (increased by 4 angstrom^3)
         Store the outputs of the two calcs in r0 and r1
         """
-        print "Workchain node identifiers: {}".format(ProcessRegistry().current_calc_node)
+        print "Workchain node identifiers: {}".format(self.calc)
 
         inputs0 = generate_scf_input_params(
-            self.inputs.structure, str(self.inputs.code), str(self.inputs.pseudo_family))
+            self.inputs.structure, str(self.inputs.code), self.inputs.pseudo_family)
 
         initial_volume = self.inputs.structure.get_cell_volume()
         new_volume = initial_volume + 4. # In ang^3
@@ -139,13 +137,13 @@ class PressureConvergence(WorkChain):
         future1 = submit(PwProcess, **inputs1)
 
         # Wait to complete before next step
-        return ToContext(r0=Outputs(future0), r1=Outputs(future1))
+        return ToContext(r0=future0, r1=future1)
 
     def put_step0_in_ctx(self):
         """
         Store the outputs of the very first step in a specific dictionary
         """
-        V, E, dE = get_volume_energy_and_derivative(self.ctx.r0['output_parameters'])
+        V, E, dE = get_volume_energy_and_derivative(self.ctx.r0.get_outputs_dict()('output_parameters'))
 
         self.ctx.step0 = {'V': V, 'E': E, 'dE': dE}
 
@@ -162,8 +160,10 @@ class PressureConvergence(WorkChain):
         r0 gets replaced with r1, r1 will get replaced by the results of the
         new calculation.
         """
-        ddE = get_second_derivative(self.ctx.r0['output_parameters'], self.ctx.r1['output_parameters'])
-        V, E, dE = get_volume_energy_and_derivative(self.ctx.r1['output_parameters'])
+        r0_out = self.ctx.r0.get_outputs_dict()
+        r1_out = self.ctx.r1.get_outputs_dict()
+        ddE = get_second_derivative(r0_out['output_parameters'], r1_out['output_parameters'])
+        V, E, dE = get_volume_energy_and_derivative(r1_out['output_parameters'])
         a,b,c = get_abc(V,E,dE,ddE)
 
         new_step_data = {'V': V, 'E': E, 'dE': dE, 'ddE': ddE,
@@ -184,15 +184,18 @@ class PressureConvergence(WorkChain):
         # Run PW                                                                                                                     
         future = submit(PwProcess, **inputs)
         # Replace r1
-        return ToContext(r1=Outputs(future))
+        return ToContext(r1=future)
         
 
     def not_converged(self):
         """
         Return True if the worflow is not converged yet (i.e., the volume changed significantly)
         """
-        return abs(self.ctx.r1['output_parameters'].dict.volume - 
-                   self.ctx.r0['output_parameters'].dict.volume) > self.inputs.volume_tolerance
+        r0_out = self.ctx.r0.get_outputs_dict()
+        r1_out = self.ctx.r1.get_outputs_dict()
+
+        return abs(r1_out['output_parameters'].dict.volume - 
+                   r0_out['output_parameters'].dict.volume) > self.inputs.volume_tolerance
 
 
     def report(self):

--- a/tutorial/scripts/simple_sync_workflow.py
+++ b/tutorial/scripts/simple_sync_workflow.py
@@ -1,9 +1,8 @@
 from create_rescale import create_diamond_fcc, rescale
 from common_wf import generate_scf_input_params
-from aiida.work.run import run
-from aiida.work.workfunction import workfunction as wf
+from aiida.work import run, Process
+from aiida.work import workfunction as wf
 from aiida.orm.data.base import Str, Float
-from aiida.work.process_registry import ProcessRegistry
 from aiida.orm import CalculationFactory, DataFactory
 
 PwCalculation = CalculationFactory('quantumespresso.pw')
@@ -13,7 +12,7 @@ labels = ["c1", "c2", "c3", "c4", "c5"]
 
 @wf
 def run_eos_wf(codename, pseudo_family, element):
-    print "Workfunction node identifiers: {}".format(ProcessRegistry().current_calc_node)
+    print "Workfunction node identifiers: {}".format(Process.current().calc)
     #Instantiate a JobCalc process and create basic structure
     JobCalc = PwCalculation.process()
     s0 = create_diamond_fcc(Str(element))
@@ -21,7 +20,7 @@ def run_eos_wf(codename, pseudo_family, element):
     calcs = {}
     for label, factor in zip(labels, scale_facs):
         s = rescale(s0,Float(factor))
-        inputs = generate_scf_input_params(s, str(codename), str(pseudo_family))
+        inputs = generate_scf_input_params(s, str(codename), Str(pseudo_family))
         print "Running a scf for {} with scale factor {}".format(element, factor)
         result = run(JobCalc,**inputs)
         calcs[label] = get_info(result)

--- a/tutorial/scripts/simple_sync_workflow.py
+++ b/tutorial/scripts/simple_sync_workflow.py
@@ -23,6 +23,7 @@ def run_eos_wf(codename, pseudo_family, element):
         inputs = generate_scf_input_params(s, str(codename), Str(pseudo_family))
         print "Running a scf for {} with scale factor {}".format(element, factor)
         result = run(JobCalc,**inputs)
+        print "RESULT: {}".format(result)
         calcs[label] = get_info(result)
 
     eos = []
@@ -44,7 +45,7 @@ def get_info(calc_results):
             calc_results['output_parameters'].dict.energy,
             calc_results['output_parameters'].dict.energy_units)
 
-def run_eos(codename='pw-5.1@localhost', pseudo_family='GBRV_lda', element="Si"):
+def run_eos(codename='qe-pw-6.2.1@localhost', pseudo_family='GBRV_lda', element="Si"):
     return run_eos_wf(Str(codename), Str(pseudo_family), Str(element))
 
 if __name__ == '__main__':


### PR DESCRIPTION
   Fixes to update to latest code for tutorial
    
    Preparing the demos for the tutorial in Bologna (May, 2018).  The
    following workflow changes have had to be made:
    * aiida.work.workfunction no longer exists, just use from aiida.work
    import workfunction or similar
    * get_inputs_template is not get_builder
    * _options is now options
    * ProcessRegistry is gone.  Can use self.calc or Process.current().calc
    to get the calculation node for the current WorkChain or workfunction
    respectively